### PR TITLE
g:NERDTreeIndicatorMapCustom is depreceated, change it to g:NERDTreeG…

### DIFF
--- a/vimrcs/nerdtree.vim
+++ b/vimrcs/nerdtree.vim
@@ -56,7 +56,7 @@ let g:WebDevIconsDefaultFolderSymbolColor = s:beige
 let g:WebDevIconsDefaultFileSymbolColor = s:blue
 
 " NERDTree Git Plugin
-let g:NERDTreeIndicatorMapCustom = {
+let g:NERDTreeGitStatusIndicatorMapCustom = {
     \ "Modified"  : "✹",
     \ "Staged"    : "✚",
     \ "Untracked" : "✭",


### PR DESCRIPTION
Hi @surajitbasak109 .
When I opened nvim using this repo, I have this message:
```
[nerd-git-status] option 'g:NERDTreeIndicatorMapCustom' is depreceated, please use 'g:NERDTreeGitStatusIndicatoraMapCustom'
```

So I made some change as mentioned above, please consider and seeing the PR.
Thanks in advance